### PR TITLE
iam terraform block and local-exec integ

### DIFF
--- a/scripts/aws_iam_user_cleanup.py
+++ b/scripts/aws_iam_user_cleanup.py
@@ -31,7 +31,7 @@ def delete_login_profile(user_name):
         client.delete_login_profile(UserName=user_name)
         print(f"Deleting login profile for {user_name}")
     except client.exceptions.NoSuchEntityException:
-        print(f"No login profile exists for {user_name}")
+        print(f"No login profile found for {user_name}")
 
 def delete_mfa_devices(user_name):
     """ Get the list of MFA devices for the user and delete each MFA device """
@@ -49,19 +49,19 @@ def delete_mfa_devices(user_name):
 
 def delete_access_keys(user_name):
     """ Delete all access keys associated with user """
-    try:
-        # Get all access keys for the specified user
-        response = client.list_access_keys(UserName=user_name)
-        access_keys = response['AccessKeyMetadata']
+    # Get all access keys for the specified user
+    response = client.list_access_keys(UserName=user_name)
+    access_keys = response['AccessKeyMetadata']
 
-        # Delete each access key
-        for key in access_keys:
-            access_key_id = key['AccessKeyId']
-            client.delete_access_key(UserName=user_name, AccessKeyId=access_key_id)
-            print(f"Deleted access key: {access_key_id} for user: {user_name}")
+    if not access_keys:
+        print(f"No access keys found for {user_name}")
+        return
 
-    except Exception as e:
-        print(f"Error deleting access keys for user {user_name}: {e}")
+    # Delete each access key
+    for key in access_keys:
+        access_key_id = key['AccessKeyId']
+        client.delete_access_key(UserName=user_name, AccessKeyId=access_key_id)
+        print(f"Deleted access key: {access_key_id} for {user_name}")
 
 def main():
     """ Get the IAM username argument and proceed with cleanup only if username is valid """

--- a/terraform/iam/.gitignore
+++ b/terraform/iam/.gitignore
@@ -1,0 +1,35 @@
+# Local .terraform directories
+**/.terraform/*
+.terraform.lock.hcl
+
+# .tfstate files
+*.tfstate
+*.tfstate.*
+
+# Crash log files
+crash.log
+crash.*.log
+
+# Exclude all .tfvars files, which are likely to contain sensitive data, such as
+# password, private keys, and other secrets. These should not be part of version 
+# control as they are data points which are potentially sensitive and subject 
+# to change depending on the environment.
+*.tfvars
+*.tfvars.json
+
+# Ignore override files as they are usually used to override resources locally and so
+# are not checked in
+override.tf
+override.tf.json
+*_override.tf
+*_override.tf.json
+
+# Include override files you do wish to add to version control using negated pattern
+# !example_override.tf
+
+# Include tfplan files to ignore the plan output of command: terraform plan -out=tfplan
+# example: *tfplan*
+
+# Ignore CLI configuration files
+.terraformrc
+terraform.rc

--- a/terraform/iam/provider.tf
+++ b/terraform/iam/provider.tf
@@ -1,0 +1,8 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.16.2"
+    }
+  }
+}

--- a/terraform/iam/users.tf
+++ b/terraform/iam/users.tf
@@ -1,0 +1,42 @@
+variable "user_info" {
+  description = "Map of AWS IAM usernames, email address tags and custom user tags"
+  type = map(object({
+    email     = string
+    user_tags = optional(map(string))
+  }))
+  default = {
+    "userA" = {
+      email = "userA@jennasrunbooks.com"
+    }
+    "userB" = {
+      email = "userB@jennasrunbooks.com"
+      user_tags = {
+        "AKIASRJ6UGTMV3JU6CU2" = "testkey1"
+      }
+    }
+  }
+}
+
+
+resource "aws_iam_user" "this" {
+  for_each = var.user_info
+  name     = each.key
+  path     = "/"
+  tags = merge(
+    var.common_tags,
+    {
+      email = each.value.email
+    },
+    each.value.user_tags
+  )
+  # Provisions the login profile for each new user and outputs their temp login password
+  provisioner "local-exec" {
+    when    = create
+    command = "python ../../scripts/aws_iam_user_password_reset.py profile -u ${each.key}"
+  }
+  # Destroys the login profile, MFA devices and access keys for each removed user
+  provisioner "local-exec" {
+    when    = destroy
+    command = "python ../../scripts/aws_iam_user_cleanup.py ${each.key}"
+  }
+}

--- a/terraform/iam/variables.tf
+++ b/terraform/iam/variables.tf
@@ -1,0 +1,9 @@
+variable "common_tags" {
+  type = map(any)
+  default = {
+    resource-owner   = "aws-landing-zone@jennasrunbooks.com"
+    environment-type = "lab"
+    provisioner      = "terraform"
+    repo             = "aws-security"
+  }
+}


### PR DESCRIPTION
- Slight modifications to the aws_iam_user_cleanup.py script for consistency
- Setup Terraform directory for PoC purposes with examples
- Terraform aws_iam_user resource block dynamically creates/destroys users based on user_info variable settings
- The local-exec provisioner is integrated into the aws_iam_user resource block to automatically create login profiles when new users are added and to automatically delete login profiles, hardware/virtual MFA devices and access keys
- The purpose for these scripts is so that users can manage their profiles, MFA devices and access keys using a self service model rather than relying on ci/cd to manage this